### PR TITLE
simple script to predeploy contracts to testnets

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,12 +19,12 @@
     "dotenv": "^6.1.0",
     "ethers": "^4.0.15",
     "fs-extra": "^8.0.1",
+    "jest": "^24.0.6",
     "solc": "^0.5.4",
     "yargs": "^12.0.5"
   },
   "devDependencies": {
     "ganache-cli": "^6.1.8",
-    "jest": "^24.8.0",
     "truffle": "^5.0.0-beta.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,12 +18,13 @@
     "detect-port": "^1.3.0",
     "dotenv": "^6.1.0",
     "ethers": "^4.0.15",
+    "fs-extra": "^8.0.1",
     "solc": "^0.5.4",
     "yargs": "^12.0.5"
   },
   "devDependencies": {
     "ganache-cli": "^6.1.8",
-    "jest": "^23.6.0",
+    "jest": "^24.8.0",
     "truffle": "^5.0.0-beta.2"
   }
 }

--- a/utils/deployContractsToTestnets.js
+++ b/utils/deployContractsToTestnets.js
@@ -42,7 +42,7 @@ function deployContractsToTestnets(buildContractsPath, appPreBuiltContractArtifa
 
               let data = JSON.stringify(strippedArtifact, null, 2);
 
-              fs.outputFile(path.join(appPreBuiltContractArtifactsPath, artifact.contractName, '.json'), data, err => {
+              fs.outputFile(path.format({ dir: appPreBuiltContractArtifactsPath, name: artifact.contractName, ext: '.json' }), data, err => {
                 if (err) {
                   throw err;
                 }

--- a/utils/deployContractsToTestnets.js
+++ b/utils/deployContractsToTestnets.js
@@ -2,7 +2,7 @@ const { deployContracts } = require('./deployContracts');
 const fs = require('fs-extra');
 
 module.exports = {
-  preDeployContracts
+  deployContractsToTestnets
 };
 
 // This function will:
@@ -13,7 +13,7 @@ module.exports = {
 // - overwrite artifact with a copy where only certain fields have been selected
 // - save this file to the appPreBuiltContractArtifactsPath directory
 
-function preDeployContracts(buildContractsPath, appPreBuiltContractArtifactsPath) {
+function deployContractsToTestnets(buildContractsPath, appPreBuiltContractArtifactsPath) {
   fs.emptyDirSync(buildContractsPath, '');
   process.env.TARGET_NETWORK = 'ropsten';
   console.log('deploying to ropsten');

--- a/utils/preDeployContracts.js
+++ b/utils/preDeployContracts.js
@@ -1,0 +1,53 @@
+const { deployContracts } = require('./deployContracts');
+
+const fs = require('fs-extra');
+
+module.exports = {
+  preDeployContracts: function(buildContractsPath, appPreBuiltContractArtifactsPath) {
+    fs.emptyDirSync(buildContractsPath, '');
+    process.env.TARGET_NETWORK = 'ropsten';
+    console.log('deploying to ropsten');
+    deployContracts()
+      .then(() => {
+        process.env.TARGET_NETWORK = 'kovan';
+        console.log('deploying to kovan');
+        return deployContracts();
+      })
+      .then(() => {
+        process.env.TARGET_NETWORK = 'rinkeby';
+        console.log('deploying to rinkeby');
+        return deployContracts();
+      })
+      .then(() => {
+        fs.readdir(buildContractsPath + '/', function(err, artifacts) {
+          for (var i = 0; i < artifacts.length; i++) {
+            fs.readJson(buildContractsPath + '/' + artifacts[i])
+              .then(artifact => {
+                const strippedArtifact = {
+                  contractName: artifact.contractName,
+                  abi: artifact.abi,
+                  bytecode: artifact.bytecode,
+                  networks: artifact.networks
+                };
+
+                let data = JSON.stringify(strippedArtifact, null, 2);
+
+                fs.outputFile(
+                  appPreBuiltContractArtifactsPath + '/' + artifact.contractName + '.json', data,
+                  err => {
+                  if (err) {
+                    throw err;
+                  }
+                });
+
+                console.log('Saved ' + artifact.contractName);
+              })
+              .catch(err => {
+                console.error(err);
+              });
+          }
+        });
+      })
+      .catch(error => console.log(error));
+  }
+};

--- a/utils/preDeployContracts.js
+++ b/utils/preDeployContracts.js
@@ -5,6 +5,14 @@ module.exports = {
   preDeployContracts
 };
 
+// This function will:
+// - clear the buildContractsPath directory
+// - set TARGET_NETWORK environment variable to a testnet
+// - call deployContracts()
+// - repeat for 3 testets
+// - overwrite artifact with a copy where only certain fields have been selected
+// - save this file to the appPreBuiltContractArtifactsPath directory
+
 function preDeployContracts(buildContractsPath, appPreBuiltContractArtifactsPath) {
   fs.emptyDirSync(buildContractsPath, '');
   process.env.TARGET_NETWORK = 'ropsten';
@@ -21,9 +29,9 @@ function preDeployContracts(buildContractsPath, appPreBuiltContractArtifactsPath
       return deployContracts();
     })
     .then(() => {
-      fs.readdir(buildContractsPath + '/', function(err, artifacts) {
+      fs.readdir(buildContractsPath, function(err, artifacts) {
         for (var i = 0; i < artifacts.length; i++) {
-          fs.readJson(buildContractsPath + '/' + artifacts[i])
+          fs.readJson(path.join(buildContractsPath, artifacts[i]))
             .then(artifact => {
               const strippedArtifact = {
                 contractName: artifact.contractName,
@@ -34,7 +42,7 @@ function preDeployContracts(buildContractsPath, appPreBuiltContractArtifactsPath
 
               let data = JSON.stringify(strippedArtifact, null, 2);
 
-              fs.outputFile(appPreBuiltContractArtifactsPath + '/' + artifact.contractName + '.json', data, err => {
+              fs.outputFile(path.join(appPreBuiltContractArtifactsPath, artifact.contractName, '.json'), data, err => {
                 if (err) {
                   throw err;
                 }

--- a/utils/preDeployContracts.js
+++ b/utils/preDeployContracts.js
@@ -1,53 +1,52 @@
 const { deployContracts } = require('./deployContracts');
-
 const fs = require('fs-extra');
 
 module.exports = {
-  preDeployContracts: function(buildContractsPath, appPreBuiltContractArtifactsPath) {
-    fs.emptyDirSync(buildContractsPath, '');
-    process.env.TARGET_NETWORK = 'ropsten';
-    console.log('deploying to ropsten');
-    deployContracts()
-      .then(() => {
-        process.env.TARGET_NETWORK = 'kovan';
-        console.log('deploying to kovan');
-        return deployContracts();
-      })
-      .then(() => {
-        process.env.TARGET_NETWORK = 'rinkeby';
-        console.log('deploying to rinkeby');
-        return deployContracts();
-      })
-      .then(() => {
-        fs.readdir(buildContractsPath + '/', function(err, artifacts) {
-          for (var i = 0; i < artifacts.length; i++) {
-            fs.readJson(buildContractsPath + '/' + artifacts[i])
-              .then(artifact => {
-                const strippedArtifact = {
-                  contractName: artifact.contractName,
-                  abi: artifact.abi,
-                  bytecode: artifact.bytecode,
-                  networks: artifact.networks
-                };
-
-                let data = JSON.stringify(strippedArtifact, null, 2);
-
-                fs.outputFile(
-                  appPreBuiltContractArtifactsPath + '/' + artifact.contractName + '.json', data,
-                  err => {
-                  if (err) {
-                    throw err;
-                  }
-                });
-
-                console.log('Saved ' + artifact.contractName);
-              })
-              .catch(err => {
-                console.error(err);
-              });
-          }
-        });
-      })
-      .catch(error => console.log(error));
-  }
+  preDeployContracts
 };
+
+function preDeployContracts(buildContractsPath, appPreBuiltContractArtifactsPath) {
+  fs.emptyDirSync(buildContractsPath, '');
+  process.env.TARGET_NETWORK = 'ropsten';
+  console.log('deploying to ropsten');
+  deployContracts()
+    .then(() => {
+      process.env.TARGET_NETWORK = 'kovan';
+      console.log('deploying to kovan');
+      return deployContracts();
+    })
+    .then(() => {
+      process.env.TARGET_NETWORK = 'rinkeby';
+      console.log('deploying to rinkeby');
+      return deployContracts();
+    })
+    .then(() => {
+      fs.readdir(buildContractsPath + '/', function(err, artifacts) {
+        for (var i = 0; i < artifacts.length; i++) {
+          fs.readJson(buildContractsPath + '/' + artifacts[i])
+            .then(artifact => {
+              const strippedArtifact = {
+                contractName: artifact.contractName,
+                abi: artifact.abi,
+                bytecode: artifact.bytecode,
+                networks: artifact.networks
+              };
+
+              let data = JSON.stringify(strippedArtifact, null, 2);
+
+              fs.outputFile(appPreBuiltContractArtifactsPath + '/' + artifact.contractName + '.json', data, err => {
+                if (err) {
+                  throw err;
+                }
+              });
+
+              console.log('Saved ' + artifact.contractName);
+            })
+            .catch(err => {
+              console.error(err);
+            });
+        }
+      });
+    })
+    .catch(error => console.log(error));
+}


### PR DESCRIPTION
Once in place, this utility function can be called from our apps with a simple script passing in the relevant paths.

The script implements the steps detailed here https://magmo.gitbook.io/developer-handbook/pre-deploying-contracts-to-testnets . 