### PR TITLE
Rename environment variables + more strict ganache start

### DIFF
--- a/bin/ganache-then-jest.js
+++ b/bin/ganache-then-jest.js
@@ -6,8 +6,8 @@ process.env.BABEL_ENV = "test";
 process.env.NODE_ENV = "test";
 process.env.PUBLIC_URL = "";
 
-if (!process.env.DEV_GANACHE_PORT) {
-  process.env.DEV_GANACHE_PORT = 8545;
+if (!process.env.GANACHE_PORT) {
+  process.env.GANACHE_PORT = 8545;
 }
 
 process.on("unhandledRejection", err => {
@@ -18,7 +18,7 @@ const { runJest } = require("../utils/runJest");
 const { deployContracts } = require("../utils/deployContracts");
 const { startGanache } = require("../utils/startGanache");
 let argv = require("yargs").argv;
-console.log(`Using port ${process.env.DEV_GANACHE_PORT} for Ganache.`);
+console.log(`Using port ${process.env.GANACHE_PORT} for Ganache.`);
 startGanache(argv).then(() => {
   deployContracts().then(() => {
     runJest().then(output => {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "magmo-devtools",
   "private": true,
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "Scripts used for Magmo development processes",
   "main": "index.js",
   "bin": {

--- a/utils/deployContracts.js
+++ b/utils/deployContracts.js
@@ -8,10 +8,10 @@ module.exports = {
     const path = require("path");
     const { spawn } = require("child_process");
     let targetNetwork = "development";
-    if (!process.env.TARGET_NETWORK && !!process.env.CHAIN_NETWORK_ID) {
+    if (!process.env.CHAIN_NETWORK && !!process.env.CHAIN_NETWORK_ID) {
       targetNetwork = getNetworkName(parseInt(process.env.CHAIN_NETWORK_ID));
-    } else if (!!process.env.TARGET_NETWORK) {
-      targetNetwork = process.env.TARGET_NETWORK;
+    } else if (!!process.env.CHAIN_NETWORK) {
+      targetNetwork = process.env.CHAIN_NETWORK;
     }
     process.env.GANACHE_HOST = process.env.GANACHE_HOST || "127.0.0.1";
     process.env.GANACHE_PORT = process.env.GANACHE_PORT || 8545;

--- a/utils/deployContracts.js
+++ b/utils/deployContracts.js
@@ -8,13 +8,13 @@ module.exports = {
     const path = require("path");
     const { spawn } = require("child_process");
     let targetNetwork = "development";
-    if (!process.env.TARGET_NETWORK && !!process.env.TARGET_NETWORK_ID) {
-      targetNetwork = getNetworkName(parseInt(process.env.TARGET_NETWORK_ID));
+    if (!process.env.TARGET_NETWORK && !!process.env.CHAIN_NETWORK_ID) {
+      targetNetwork = getNetworkName(parseInt(process.env.CHAIN_NETWORK_ID));
     } else if (!!process.env.TARGET_NETWORK) {
       targetNetwork = process.env.TARGET_NETWORK;
     }
-    process.env.DEV_GANACHE_HOST = process.env.DEV_GANACHE_HOST || "127.0.0.1";
-    process.env.DEV_GANACHE_PORT = process.env.DEV_GANACHE_PORT || 8545;
+    process.env.GANACHE_HOST = process.env.GANACHE_HOST || "127.0.0.1";
+    process.env.GANACHE_PORT = process.env.GANACHE_PORT || 8545;
     // It is assumed that truffle is installed as a dependency of your project.
     const trufflePath = path.resolve(
       __dirname,

--- a/utils/networkSetup.js
+++ b/utils/networkSetup.js
@@ -9,7 +9,7 @@ module.exports = {
   getGanacheProvider: function() {
     const ethers = require("ethers");
     return new ethers.providers.JsonRpcProvider(
-      `http://${process.env.DEV_GANACHE_HOST}:${process.env.DEV_GANACHE_PORT}`
+      `http://${process.env.GANACHE_HOST}:${process.env.GANACHE_PORT}`
     );
   },
   getPrivateKeyWithEth: function() {
@@ -18,14 +18,14 @@ module.exports = {
   getWalletWithEthAndProvider: function() {
     const ethers = require("ethers");
     const ganacheProvider = new ethers.providers.JsonRpcProvider(
-      `http://${process.env.DEV_GANACHE_HOST}:${process.env.DEV_GANACHE_PORT}`
+      `http://${process.env.GANACHE_HOST}:${process.env.GANACHE_PORT}`
     );
     return new ethers.Wallet(privateKeyWithEth, ganacheProvider);
   },
   getNetworkId: async () => {
     const ethers = require("ethers");
     const ganacheProvider = new ethers.providers.JsonRpcProvider(
-      `http://${process.env.DEV_GANACHE_HOST}:${process.env.DEV_GANACHE_PORT}`
+      `http://${process.env.GANACHE_HOST}:${process.env.GANACHE_PORT}`
     );
     return (await ganacheProvider.getNetwork()).chainId;
   },

--- a/utils/startGanache.js
+++ b/utils/startGanache.js
@@ -6,13 +6,10 @@ module.exports = {
     configureEnvVariables();
     let verbose = argv.v;
     let deterministic = argv.d;
-    let network_id =
-      argv.i ||
-      process.env.DEV_GANACHE_NETWORK_ID ||
-      process.env.TARGET_NETWORK_ID;
+    let network_id = argv.i || process.env.GANACHE_NETWORK_ID;
     let blockTime = argv.b || process.env.GANACHE_BLOCK_TIME;
 
-    process.env.DEV_GANACHE_PORT = process.env.DEV_GANACHE_PORT || 8545;
+    process.env.GANACHE_PORT = process.env.GANACHE_PORT || 8545;
     //Default accounts to seed so we can have accounts with 1M ether for testing
     var accounts = [
       {
@@ -32,22 +29,22 @@ module.exports = {
       }
     ];
     var ganache = require("ganache-cli");
-    Logger.log(`Starting ganache on port ${process.env.DEV_GANACHE_PORT}`);
+    Logger.log(`Starting ganache on port ${process.env.GANACHE_PORT}`);
 
     const detect = require("detect-port");
-    return detect(process.env.DEV_GANACHE_PORT)
+    return detect(process.env.GANACHE_PORT)
       .then(_port => {
-        const portInUse = _port != process.env.DEV_GANACHE_PORT;
+        const portInUse = _port != process.env.GANACHE_PORT;
         if (portInUse) {
           Logger.log(
             `Port ${
-              process.env.DEV_GANACHE_PORT
+              process.env.GANACHE_PORT
             } in use. Assuming a ganache instance on that port.`
           );
           return Promise.resolve();
         } else {
           var ganacheServer = ganache.server({
-            port: process.env.DEV_GANACHE_PORT,
+            port: process.env.GANACHE_PORT,
             network_id: network_id,
             accounts,
             logger: Logger,
@@ -58,7 +55,7 @@ module.exports = {
 
           const { promisify } = require("util");
           const listenAsync = promisify(ganacheServer.listen);
-          return listenAsync(process.env.DEV_GANACHE_PORT);
+          return listenAsync(process.env.GANACHE_PORT);
         }
       })
       .catch(err => {


### PR DESCRIPTION
- When starting ganache, do not use `TARGET_NETWORK_ID`.
- Ganache is always used for testing and development, so the `DEV` prefix for Ganache environment variables is unnecessary.
- Getting rid of `TARGET_NETWORK` env variables in favor of `CHAIN_NETWORK`